### PR TITLE
fix: Support capital letters in urls

### DIFF
--- a/api/src/main/kotlin/com/github/samunohito/mfm/api/parser/inline/UrlParser.kt
+++ b/api/src/main/kotlin/com/github/samunohito/mfm/api/parser/inline/UrlParser.kt
@@ -36,7 +36,7 @@ object UrlParser : IMfmParser {
         closeRegexBracket,
       ),
       // このパターンに合致する文字が登場するまでを繰り返し検索する
-      RegexParser(Regex("[.,a-z0-9_/:%#@\\\\$&?!~=+\\-]+")),
+      RegexParser(Regex("[.,a-zA-Z0-9_/:%#@\\\\$&?!~=+\\-]+")),
     )
 
     override fun find(input: String, startAt: Int, context: IMfmParserContext): IMfmParserResult {


### PR DESCRIPTION
僕の日本語が下手クソだからごめんなさい。mfm.jsには[このライン](https://github.com/misskey-dev/mfm.js/blob/6aaf68089023c6adebe44123eebbc4dcd75955e0/src/internal/parser.ts#L665)`/i`がありますので、A-Zが必要はないですけど、mfm.ktにはこの`/i`が使えないから必要です。

Posting in English just in case my Japanese is not clear (I am learning, but far from perfect!) The regex at [this line in mfm.js](https://github.com/misskey-dev/mfm.js/blob/6aaf68089023c6adebe44123eebbc4dcd75955e0/src/internal/parser.ts#L665) has a `/i` at the end that makes it match letters case insensitive. Since the kotlin version doesn't use this, it needs to add the A-Z into the regex. This will make it possible to match a link with capital letters like https://youtu.be/OIBODIPC_8Y for example.